### PR TITLE
Added DualSense™ remote names to INF

### DIFF
--- a/BthPS3/BthPS3.inf
+++ b/BthPS3/BthPS3.inf
@@ -114,7 +114,7 @@ HKR,Parameters,NAVIGATIONSupportedNames,0x00010002,"Navigation Controller"
 ; Collection of supported remote names for MOTION device
 HKR,Parameters,MOTIONSupportedNames,0x00010002,"Motion Controller"
 ; Collection of supported remote names for WIRELESS device
-HKR,Parameters,WIRELESSSupportedNames,0x00010002,"Wireless Controller"
+HKR,Parameters,WIRELESSSupportedNames,0x00010002,"Wireless Controller","DualSense Wireless Controller","DualSense Edge Wireless Controller"
 ; Sub-key to store occupied slot information
 HKR,"Parameters\Devices",,0x00000010,
 


### PR DESCRIPTION
Added the following names to the `WIRELESSSupportedNames` since it might come in handy for future R&D:

- "DualSense Wireless Controller"
- "DualSense Edge Wireless Controller"

**Caution:** DualSense on BthPS3 is untested, this might not even do us any good without more modifications.