### PR TITLE
Possible fix for hibernate/suspend crash bug

### DIFF
--- a/BthPS3PSM/Queue.c
+++ b/BthPS3PSM/Queue.c
@@ -104,14 +104,28 @@ BthPS3PSM_EvtIoStop(
 {
     UNREFERENCED_PARAMETER(Queue);
 
+    FuncEntry(TRACE_QUEUE);
+
     if (ActionFlags & WdfRequestStopActionSuspend)
     {
+        TraceVerbose(
+            TRACE_QUEUE,
+            "StopAcknowledge Request=0x%p (Suspend)",
+            Request
+        );
         WdfRequestStopAcknowledge(Request, FALSE);
     }
     else if (ActionFlags & WdfRequestStopActionPurge)
     {
+        TraceVerbose(
+            TRACE_QUEUE,
+            "CancelSentRequest Request=0x%p (Purge)",
+            Request
+        );
         WdfRequestCancelSentRequest(Request);
     }
+
+    FuncExitNoReturn(TRACE_QUEUE);
 }
 
 //

--- a/BthPS3PSM/Queue.c
+++ b/BthPS3PSM/Queue.c
@@ -65,8 +65,9 @@ BthPS3PSM_QueueInitialize(
     );
 
     //
-    // This is the only callback we're intercepting
-    // 
+    // Required for device removal: cancel forwarded requests so queue can drain
+    //
+    queueConfig.EvtIoStop = BthPS3PSM_EvtIoStop;
     queueConfig.EvtIoInternalDeviceControl = BthPS3PSMEvtIoInternalDeviceControl;
 
     if (!NT_SUCCESS(status = WdfIoQueueCreate(
@@ -87,6 +88,30 @@ BthPS3PSM_QueueInitialize(
     }
 
     return status;
+}
+
+//
+// Called when device is suspended or removed; allows queue to drain by
+// cancelling forwarded requests that may otherwise hang during teardown
+//
+_Use_decl_annotations_
+VOID
+BthPS3PSM_EvtIoStop(
+    _In_ WDFQUEUE Queue,
+    _In_ WDFREQUEST Request,
+    _In_ ULONG ActionFlags
+)
+{
+    UNREFERENCED_PARAMETER(Queue);
+
+    if (ActionFlags & WdfRequestStopActionSuspend)
+    {
+        WdfRequestStopAcknowledge(Request, FALSE);
+    }
+    else if (ActionFlags & WdfRequestStopActionPurge)
+    {
+        WdfRequestCancelSentRequest(Request);
+    }
 }
 
 //

--- a/BthPS3PSM/Queue.h
+++ b/BthPS3PSM/Queue.h
@@ -49,6 +49,7 @@ BthPS3PSM_QueueInitialize(
 //
 // Events from the IoQueue object
 //
+EVT_WDF_IO_QUEUE_IO_STOP BthPS3PSM_EvtIoStop;
 EVT_WDF_IO_QUEUE_IO_INTERNAL_DEVICE_CONTROL BthPS3PSMEvtIoInternalDeviceControl;
 EVT_WDF_REQUEST_COMPLETION_ROUTINE UrbFunctionSelectConfigurationCompleted;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.10.{build}.0
+version: 2.11.{build}.0
 build_cloud: WIN-LKR467JS4GL
 image: Windows
 environment:


### PR DESCRIPTION
May fix #92 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bluetooth device stability: IO queues now properly drain during suspension and removal. Pending and in-flight requests are acknowledged or canceled (including purge scenarios), reducing resource leaks and hung operations and producing clearer trace logs for diagnostics.

* **Chores**
  * Build/config updated with a minor version bump and platform list adjustment in CI settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->